### PR TITLE
Initial draft of code of conduct for Djangonaut Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ know and love. :heart:
 - [Djangonaut Guide](djangonauts.md)
 - [Navigator Guide](navigators.md)
 - [Captain Guide](captains.md)
+- [Code of Conduct](conduct.md)

--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,133 @@
+# Code of Conduct
+
+Djangonaut Space is a place where we look to facilitate the growth of
+some of the future contributors to the Django community. To that end
+we are dedicated to providing a harassment-free environment for everyone,
+regardless of gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age, religion,
+or nationality.
+
+Our code of conduct is based on [Django's Code of Conduct](https://www.djangoproject.com/conduct/).
+This code of conduct applies to
+all areas involved with Djangonaut Space. This includes Discord, email,
+video conferences, and any channels community uses for communication.
+In addition, violations of this code outside these spaces may affect a
+person's ability to participate within them.
+
+If you believe someone is violating the code of conduct, we ask that you
+report it by emailing conduct@djangonaut.space.
+
+- **Be friendly and patient.**
+
+- **Be welcoming.** We strive to be a community that welcomes and supports
+  people of all backgrounds and identities. This includes, but is not
+  limited to members of any race, ethnicity, culture, national origin,
+  colour, immigration status, social and economic class, educational
+  level, sex, sexual orientation, gender identity and expression, age,
+  size, family status, political belief, religion, and mental and
+  physical ability.
+
+- **Be considerate.** Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect
+  users and colleagues, and you should take those consequences into
+  account when making decisions. Remember that we're a world-wide
+  community, so you might not be communicating in someone else's primary
+  language.
+
+- **Be respectful.** Not all of us will agree all the time, but disagreement
+  is no excuse for poor behavior and poor manners. We might all experience
+  some frustration now and then, but we cannot allow that frustration to
+  turn into a personal attack. It’s important to remember that a community
+  where people feel uncomfortable or threatened is not a productive one.
+  Members of the Djangonaut Space community should be respectful when dealing
+  with other members as well as with people outside the community.
+
+- **Be careful in the words that you choose.** We are a community of professionals,
+  and we conduct ourselves professionally. Be kind to others. Do not insult
+  or put down other participants. Harassment and other exclusionary behavior
+  aren't acceptable. This includes, but is not limited to:
+  -  Violent threats or language directed against another person.
+  -  Discriminatory jokes and language.
+  -  Posting sexually explicit or violent material.
+  -  Posting (or threatening to post) other people's personally identifying information ("doxing").
+  -  Personal insults, especially those using racist or sexist terms.
+  -  Unwelcome sexual attention.
+  -  Repeated or inappropriate direct messaging on any communication platform.
+  -  Advocating for, or encouraging, any of the above behavior.
+  -  Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+- **When we disagree, try to understand why.** Disagreements, both social and
+  technical, happen all the time and Django is no exception. It is important
+  that we resolve disagreements and differing views constructively. Remember
+  that we’re different. Different people have different perspectives on issues.
+  Being unable to understand why someone holds a viewpoint doesn’t mean
+  that they’re wrong. Don’t forget that it is human to err and blaming each
+  other doesn’t get us anywhere. Instead, focus on helping to resolve issues
+  and learning from mistakes.
+
+
+## Reporting a code of conduct violation
+
+If you believe someone is violating the code of conduct we ask that you report it
+to the Djangonaut Space organizers by emailing conduct@djangonaut.space. All
+reports will be kept confidential. In some cases we may determine that a public
+statement will need to be made. If that's the case, the identities of all victims
+and reporters will remain confidential unless those individuals instruct us otherwise.
+
+**If you believe anyone is in physical danger, please notify appropriate law enforcement
+first.** If you are unsure what law enforcement agency is appropriate,
+please include this in your report and we will attempt to notify them.
+
+### What to include in your report
+
+In your report please include:
+- Your contact info (so we can get in touch with you if we need to follow up)
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+- When and where the incident occurred. Please be as specific as possible.
+- Your account of what occurred. If there is a publicly available record please include a link.
+- Any extra context you believe existed for the incident.
+- If you believe this incident is ongoing.
+- Any other information you believe we should have.
+
+### What happens after you file a report?
+
+You will receive an email from the Djangonaut Space organizers acknowledging
+receipt as quickly as we can.
+
+The organizers will immediately meet to review the incident and determine:
+
+- What happened.
+- Whether this event constitutes a code of conduct violation.
+- Who the bad actor was.
+- Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+
+If this is determined to be an ongoing incident or a threat to physical safety, the
+organizers' immediate priority will be to protect everyone involved. This means we
+may delay an "official" response until we believe that the situation has ended and
+that everyone is physically safe.
+
+Once the organizers have a complete account of the events they will make a
+decision as to how to response. Responses may include:
+
+- Nothing (if we determine no violation occurred).
+- A private reprimand from the working group to the individual(s) involved.
+- A public reprimand.
+- A permanent or temporary ban from Djangonaut Space's platforms and/or the
+  program itself.
+- A request for a public or private apology.
+- An escalation to the Django Code of Conduct Working Group for action
+  within the broader Django community.
+
+We'll respond within one week to the person who filed the report with
+either a resolution or an explanation of why the situation is not yet resolved.
+
+Once we've determined our final action, we'll contact the original
+reporter to let them know what action (if any) we'll be taking. We'll
+take into account feedback from the reporter on the appropriateness of
+our response, but we don't guarantee we'll act on it.
+
+### What if your report concerns a possible violation by an organizer?
+
+If you feel uncomfortable filing a report with the Djangonaut Space organizers
+we recommend that you file a report with Django's Code of Conduct Working Group.
+[You can find those guidelines here.](https://www.djangoproject.com/conduct/reporting/)

--- a/conduct.md
+++ b/conduct.md
@@ -15,7 +15,7 @@ In addition, violations of this code outside these spaces may affect a
 person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you
-report it by emailing conduct@djangonaut.space.
+report it by emailing CoC@djangonaut.space.
 
 - **Be friendly and patient.**
 
@@ -69,7 +69,7 @@ report it by emailing conduct@djangonaut.space.
 ## Reporting a code of conduct violation
 
 If you believe someone is violating the code of conduct we ask that you report it
-to the Djangonaut Space organizers by emailing conduct@djangonaut.space. All
+to the Djangonaut Space organizers by emailing CoC@djangonaut.space. All
 reports will be kept confidential. In some cases we may determine that a public
 statement will need to be made. If that's the case, the identities of all victims
 and reporters will remain confidential unless those individuals instruct us otherwise.


### PR DESCRIPTION
This is largely a reproduction of Django's code of conduct as well as their reporting guidelines. I adjusted some small details to better fit our group from my opinion.

- Included inappropriate DMing
- Adjusted the referenced spaces (Django references IRC a lot)
- Removed the stated deadline the reporting initial response window (it was 24 hours)
- Removed the reporting action of forced vacation
- Added the reporting action of escalating to Django's CoC working group
- Revised the section on what to do in case of reporting a violation with an organizer