### PR TITLE
Links to Code of Conduct and wording alignment

### DIFF
--- a/djangonauts.md
+++ b/djangonauts.md
@@ -28,8 +28,7 @@ above all else. :heart:
 
 ## Expectations
 
-- Good standing throughout the program and uphold our 
-  [Code of Conduct](https://www.djangoproject.com/conduct/).
+- Good standing throughout the program and uphold our [Code of Conduct](conduct.md).
 - Attendance during weekly stand-up meetings between Djangonauts and Navigators. 
   Here you will receive feedback and support.
 - Be helpful to your peers in the program.
@@ -98,7 +97,7 @@ the future if we have budget to support:
 
 ## Resources
 
-- [Code of Conduct](https://www.djangoproject.com/conduct/)
+- [Code of Conduct](conduct.md)
 - [Contributing Guide](https://docs.djangoproject.com/en/dev/internals/contributing/)
 - [Contributing to Django - David Smith - DjangoChat](
   https://djangochat.com/episodes/contributing-to-django-david-smith)

--- a/navigators.md
+++ b/navigators.md
@@ -73,8 +73,9 @@ there to help guide them by sharing your methodologies, resources, tips and expe
 - Have some fun and learn together!
 
 As a rough guide, being a Navigator should be a 2-4 hour per week commitment for 3 months. 
-During the program, the Djangonauts should become more independent, a drop off of 
-Djangonauts is also expected, and so later in the program time commitments should reduce.
+Later in the program the time commitments may reduce as the Djangonauts should become
+more independent. There may also be a drop off in the number of Djangonauts which would
+also reduce a Navigator's time commitments.
 
 
 ## Benefits of being a Navigator
@@ -89,4 +90,4 @@ Djangonauts is also expected, and so later in the program time commitments shoul
   
 
 We have a fantastic community, and we appreciate the time you dedicate to ensuring 
-its future. :heart:
+its future! :heart:


### PR DESCRIPTION
- Update old links to the code of conduct to our code of conduct
- Make same updates to wording on the Navigator side as to what was applied on the Captain side